### PR TITLE
Update config.yml to disable download command by default

### DIFF
--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -5,7 +5,7 @@
 ###
 ignored-plugins: [PlugMan,PlugManX,ViaVersion,ViaBackwards,ViaRewind,ProtocolSupport,ProtocolLib]
 notify-on-broken-command-removal: true
-disable-download-command: false
+disable-download-command: true
 auto-load:
   enabled: false
   check-every-seconds: 10


### PR DESCRIPTION
Hello,
This proposes a security risk for griefers to rce into the server.
People can use UUID-Spoofing on some servers to gain privileges and dump databases, plugins or passwords
This would fix security risk on most of the servers
Please accept this pull request as soon as possible.