### PR TITLE
Added support for the 1.20.4 CommandDispatcher field change.

### DIFF
--- a/src/main/java/com/rylinaux/plugman/util/BukkitCommandWrap.java
+++ b/src/main/java/com/rylinaux/plugman/util/BukkitCommandWrap.java
@@ -215,7 +215,12 @@ public class BukkitCommandWrap {
             this.bField.setAccessible(true);
         } catch (NoSuchFieldException | ClassNotFoundException e) {
             if (this.bField == null) try {
-                this.bField = Class.forName("net.minecraft.commands.CommandDispatcher").getDeclaredField("g");
+                Class<?> commandDispatcherClass = Class.forName("net.minecraft.commands.CommandDispatcher");
+                if (commandDispatcherClass.getDeclaredField("g").getType() == com.mojang.brigadier.CommandDispatcher.class) {
+                    this.bField = commandDispatcherClass.getDeclaredField("g");
+                } else {
+                    this.bField = commandDispatcherClass.getDeclaredField("h");
+                }
                 this.bField.setAccessible(true);
             } catch (NoSuchFieldException | ClassNotFoundException ex) {
                 ex.addSuppressed(e);


### PR DESCRIPTION
The CommandDispatcher class has been updated in the latest version of Spigot (1.20.4), causing the field to no longer be called "g" but "h" instead.